### PR TITLE
small updates

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,20 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  // Temporary hack to fix the top-level await issue in ethereumjs
-  webpack: (config, { webpack }) => {
-    config.resolve.fallback = {
-      ...config.resolve.fallback,
-      "stream/web": "web-streams-polyfill",
-    };
-    config.plugins.push(
-      new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
-        resource.request = resource.request.replace(/^node:/, "");
-      }),
-    );
-
-    return config;
-  },
+    reactStrictMode: true,
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --experimental-build-mode compile",
     "start": "next start",
     "lint": "next lint"
   },

--- a/src/wagmi.ts
+++ b/src/wagmi.ts
@@ -1,35 +1,35 @@
-import { createConfig } from "wagmi";
+import { createConfig, custom } from "wagmi";
 import { hardhat } from "wagmi/chains";
 import { coinbaseWallet, injected, walletConnect } from "wagmi/connectors";
 
-import { createMemoryClient, tevmTransport } from "tevm";
+import { createMemoryClient } from "tevm";
 import { createCommon, tevmDefault } from "tevm/common";
 
 const customCommon = createCommon({
-  ...tevmDefault,
-  id: hardhat.id,
-  loggingLevel: "warn",
-  eips: [],
-  hardfork: "cancun",
+...tevmDefault,
+id: hardhat.id,
+loggingLevel: "warn",
+eips: [],
+hardfork: "cancun",
 });
 export const memoryClient = createMemoryClient({ common: customCommon });
 
 export const config = createConfig({
-  chains: [hardhat],
-  connectors: [
-    injected(),
-    coinbaseWallet({ appName: "Create Wagmi" }),
-    walletConnect({ projectId: "3a8170812b534d0ff9d794f19a901d64" }),
-  ],
-  ssr: true,
-  transports: {
-    [hardhat.id]: tevmTransport(memoryClient),
-  },
-  cacheTime: 0,
+chains: [hardhat],
+connectors: [
+injected(),
+coinbaseWallet({ appName: "Create Wagmi" }),
+walletConnect({ projectId: "3a8170812b534d0ff9d794f19a901d64" }),
+],
+ssr: true,
+transports: {
+[hardhat.id]: custom(memoryClient),
+},
+cacheTime: 0,
 });
 
 declare module "wagmi" {
-  interface Register {
-    config: typeof config;
-  }
+interface Register {
+config: typeof config;
+}
 }


### PR DESCRIPTION
- remove unnecessary webpack config. It used to be necessary but is no longer
- Switch to using `custom` from wagmi rather than tevmTransport. tevmTransport is deprecated and will be replaced with createTevmTransport. In meantime using `custom` will guarantee things won't break when that happens
- Update build script to not prerender. Prerendering breaks when tevm is imported for some reason so this is a temporary workaround